### PR TITLE
Wrap body content in centered container

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -12,6 +12,12 @@ body{
     height: 100%;
 }
 
+#page-container{
+    position: relative;
+    width: 650px;
+    margin: 0 auto;
+}
+
 /*##################################################################*/
 /*Configuracao do topo das divs*/
 /*##################################################################*/

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     </script>
 </head>
 <body class="Corpo" onmousedown="change()" onmouseup="changeback()" ondragstart="return false" ondrop="return false" onselect="return false">
+    <div id="page-container">
     <div id="BoxDeCima">
         <div>
             <img id="SimpleButton" src="img/UI/SimpleButton.png"></img>
@@ -240,4 +241,5 @@
         <img id="poring" src='img/poring-ragnarok.gif'>
     </div>
     <script type="text/javascript" src="js/slideshow.js"></script>
+    </div>
 </body>


### PR DESCRIPTION
## Summary
- wrap all body contents in a `#page-container`
- center the container via CSS

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68501ee5629c83238056234372b67882